### PR TITLE
Accept phone subscriptions and enable sending notifications to new subscribers

### DIFF
--- a/govdelivery/api.py
+++ b/govdelivery/api.py
@@ -83,8 +83,9 @@ class GovDelivery(object):
 
         return response_parser(unparsed_response.text)
 
-    def create_subscriber(self, email_address, send_notifications=False, digest_for=0):
-        payload = xml_payloads.create_email_subscriber(email_address, send_notifications, digest_for)
+    def create_subscriber(self, contact_details, contact_method="email", send_notifications=False, digest_for=0):
+        payload = xml_payloads.create_subscriber(contact_details, contact_method, send_notifications, digest_for)
+
         path = self.translate_path('/api/account/$account_code/subscribers.xml')
         return self.call_api(path, "post", payload)
 
@@ -96,38 +97,37 @@ class GovDelivery(object):
         path = self.translate_path('/api/account/$account_code/topics.xml')
         return self.call_api(path, "get", response_parser=xml_response_parsers.visible_category_xml_as_dict)
 
-    def get_subscriber_categories(self, email_address):
-        subscriber_id = base64.b64encode(email_address)
+    def get_subscriber_categories(self, contact_details):
+        subscriber_id = base64.b64encode(contact_details)
         path = self.translate_path('/api/account/$account_code/subscribers/$subscriber_id/categories.xml', subscriber_id=subscriber_id)
         return self.call_api(path)
 
-    def set_subscriber_categories(self, email_address, category_codes):
-        subscriber_id = base64.b64encode(email_address)
+    def set_subscriber_categories(self, contact_details, category_codes):
+        subscriber_id = base64.b64encode(contact_details)
         path = self.translate_path('/api/account/$account_code/subscribers/$subscriber_id/categories.xml', subscriber_id=subscriber_id)
         payload = xml_payloads.set_subscriber_categories(category_codes)
         return self.call_api(path, "put", payload)
 
-    def get_subscriber_topics(self, email_address):
-        subscriber_id = base64.b64encode(email_address)
+    def get_subscriber_topics(self, contact_details):
+        subscriber_id = base64.b64encode(contact_details)
         path = self.translate_path('/api/account/$account_code/subscribers/$subscriber_id/topics.xml', subscriber_id=subscriber_id)
         return self.call_api(path, response_parser=xml_response_parsers.subscriber_topics_as_list)
 
-    def set_subscriber_topics(self, email_address, topic_codes, insert=False):
-        subscriber_id = base64.b64encode(email_address)
+    def set_subscriber_topics(self, contact_details, contact_method="email", topic_codes, insert=False):
+        subscriber_id = base64.b64encode(contact_details)
         topic_code_set = set(topic_codes)
 
         path = self.translate_path('/api/account/$account_code/subscriptions.xml')
-        payload = xml_payloads.set_subscriber_topics(topic_code_set, email_address)
+        payload = xml_payloads.set_subscriber_topics(topic_code_set, contact_details, contact_method)
         return self.call_api(path, "post", payload)
-    
-    def set_subscriber_answers_to_question(self, email_address, question_id, answer_text):
-        subscriber_id =base64.b64encode(email_address)
+
+    def set_subscriber_answers_to_question(self, contact_details, question_id, answer_text):
+        subscriber_id =base64.b64encode(contact_details)
         question_id_encoded = base64.b64encode(question_id)
 
         path = self.translate_path('/api/account/$account_code/subscribers/$subscriber_id/questions/$question_id_encoded/responses.xml',
             subscriber_id=subscriber_id,
             question_id_encoded=question_id_encoded)
-        
+
         payload = xml_payloads.free_response_to_question(question_id_encoded, answer_text)
         return self.call_api(path, "put", payload)
-

--- a/govdelivery/api.py
+++ b/govdelivery/api.py
@@ -102,10 +102,10 @@ class GovDelivery(object):
         path = self.translate_path('/api/account/$account_code/subscribers/$subscriber_id/categories.xml', subscriber_id=subscriber_id)
         return self.call_api(path)
 
-    def set_subscriber_categories(self, contact_details, category_codes):
+    def set_subscriber_categories(self, contact_details, category_codes, send_notifications=False):
         subscriber_id = base64.b64encode(contact_details)
         path = self.translate_path('/api/account/$account_code/subscribers/$subscriber_id/categories.xml', subscriber_id=subscriber_id)
-        payload = xml_payloads.set_subscriber_categories(category_codes)
+        payload = xml_payloads.set_subscriber_categories(category_codes, send_notifications)
         return self.call_api(path, "put", payload)
 
     def get_subscriber_topics(self, contact_details):
@@ -113,12 +113,11 @@ class GovDelivery(object):
         path = self.translate_path('/api/account/$account_code/subscribers/$subscriber_id/topics.xml', subscriber_id=subscriber_id)
         return self.call_api(path, response_parser=xml_response_parsers.subscriber_topics_as_list)
 
-    def set_subscriber_topics(self, contact_details, contact_method="email", topic_codes, insert=False):
-        subscriber_id = base64.b64encode(contact_details)
+    def set_subscriber_topics(self, contact_details, topic_codes, contact_method="email", send_notifications=False):
         topic_code_set = set(topic_codes)
 
         path = self.translate_path('/api/account/$account_code/subscriptions.xml')
-        payload = xml_payloads.set_subscriber_topics(topic_code_set, contact_details, contact_method)
+        payload = xml_payloads.set_subscriber_topics(topic_code_set, contact_details, contact_method, send_notifications)
         return self.call_api(path, "post", payload)
 
     def set_subscriber_answers_to_question(self, contact_details, question_id, answer_text):

--- a/govdelivery/xml_payloads.py
+++ b/govdelivery/xml_payloads.py
@@ -1,4 +1,15 @@
+import re
+
 from string import Template
+
+
+def format_phone(phone):
+    # if phone starts with + or 1, strip those characters
+    phone = phone.lstrip('+1')
+    # strip all other non-digit characters
+    phone = re.sub('\D', '', phone)
+
+    return phone
 
 
 def create_subscriber(contact_details,
@@ -7,8 +18,13 @@ def create_subscriber(contact_details,
                       digest_for=0):
 
     send_notifications = str(send_notifications).lower()
+    country_code = ''
+    if contact_method == 'phone':
+        contact_details = format_phone(contact_details)
+        country_code = '<country-code>#</country-code>'
     subscriber_template = """<subscriber>
     <$contact_method>$contact_details</$contact_method>
+    $country_code
     <send-notifications type='boolean'>$send_notifications</send-notifications>
     <digest-for>$digest_for</digest-for>
   </subscriber>"""

--- a/govdelivery/xml_payloads.py
+++ b/govdelivery/xml_payloads.py
@@ -1,13 +1,14 @@
 from string import Template
 
 
-def create_email_subscriber(email_address,
-                            send_notifications=False,
-                            digest_for=0):
+def create_subscriber(contact_details,
+                      contact_method,
+                      send_notifications=False,
+                      digest_for=0):
 
     send_notifications = str(send_notifications).lower()
     subscriber_template = """<subscriber>
-    <email>$email_address</email>
+    <$contact_method>$contact_details</$contact_method>
     <send-notifications type='boolean'>$send_notifications</send-notifications>
     <digest-for>$digest_for</digest-for>
   </subscriber>"""
@@ -39,7 +40,10 @@ def set_subscriber_categories(codes, send_notifications=False):
     return template.substitute(locals())
 
 
-def set_subscriber_topics(codes, email, send_notifications=False):
+def set_subscriber_topics(codes,
+                          contact_details,
+                          contact_method,
+                          send_notifications=False):
     send_notifications = str(send_notifications).lower()
 
     topics_xml = ""
@@ -50,7 +54,7 @@ def set_subscriber_topics(codes, email, send_notifications=False):
                       """ % code
 
     xml_template = """<subscriber>
-    <email>$email</email>
+    <$contact_method>$contact_details</$contact_method>
     <send-notifications type='boolean'>$send_notifications</send-notifications>
     <topics type='array'>
         $topics_xml


### PR DESCRIPTION
We will soon be adding the ability to let people subscribe with a phone number to receive text messages via the GovDelivery Wireless Alerts feature.

The intent of this PR is to modify the API methods to allow for doing this. The basic need was to modify the XML for creating subscribers and setting subscriber topics to be able to use the `phone` node instead of `email` when appropriate.

The logic here is predicated on the notion that GovDelivery's API will take a phone number that is digits only, no separators. [The example in their docs](https://developer.govdelivery.com/api/comm_cloud_v1/Default.htm#API/Comm%20Cloud%20V1/API_CommCloudV1_Subscriptions_AddSubscription.htm) shows hyphen separators, but they do not explicitly say those are required. If they are, we'll have to add some code to `format_phone` to add those in.

/cc @jimmynotjim