### PR TITLE
Updating URL to the Comms Cloud V1 documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Currently, you can subscribe a user, manage their topic and category
 subscriptions, and get the list of available topics.
 
 The govdelivery API is described here:
-http://knowledge.govdelivery.com/display/API/API+Methods
+http://developer.govdelivery.com/api/comm_cloud_v1/Default.htm
 
 Dependencies
 ------------


### PR DESCRIPTION
Hi there, we've moved our API documentation to developer.govdelivery.com . Here's a quick update to the link in the README.