### PR TITLE
Add ability to set subscriber answers to select questions

### DIFF
--- a/govdelivery/api.py
+++ b/govdelivery/api.py
@@ -131,8 +131,6 @@ class GovDelivery(object):
         payload = xml_payloads.free_response_to_question(question_id_encoded, answer_text)
         return self.call_api(path, "put", payload)
 
-    set_subscriber_answer_to_free_response_question = set_subscriber_answers_to_question
-
     def set_subscriber_answer_to_select_question(
         self,
         contact_details,
@@ -144,8 +142,11 @@ class GovDelivery(object):
         answer_id_encoded = base64.b64encode(answer_id)
 
         path = self.translate_path(
-            '/api/account/$account_code/subscribers/$subscriber_id/questions/'
-            '$question_id_encoded/responses.xml',
+            '/api'
+            '/account/$account_code'
+            '/subscribers/$subscriber_id'
+            '/questions/$question_id_encoded'
+            '/responses.xml',
             subscriber_id=subscriber_id,
             question_id_encoded=question_id_encoded,
             answer_id_encoded=answer_id_encoded

--- a/govdelivery/api.py
+++ b/govdelivery/api.py
@@ -130,3 +130,29 @@ class GovDelivery(object):
 
         payload = xml_payloads.free_response_to_question(question_id_encoded, answer_text)
         return self.call_api(path, "put", payload)
+
+    set_subscriber_answer_to_free_response_question = set_subscriber_answers_to_question
+
+    def set_subscriber_answer_to_select_question(
+        self,
+        contact_details,
+        question_id,
+        answer_id
+    ):
+        subscriber_id = base64.b64encode(contact_details)
+        question_id_encoded = base64.b64encode(question_id)
+        answer_id_encoded = base64.b64encode(answer_id)
+
+        path = self.translate_path(
+            '/api/account/$account_code/subscribers/$subscriber_id/questions/'
+            '$question_id_encoded/responses.xml',
+            subscriber_id=subscriber_id,
+            question_id_encoded=question_id_encoded,
+            answer_id_encoded=answer_id_encoded
+        )
+
+        payload = xml_payloads.select_response_to_question(
+            question_id_encoded,
+            answer_id_encoded
+        )
+        return self.call_api(path, "put", payload)

--- a/govdelivery/xml_payloads.py
+++ b/govdelivery/xml_payloads.py
@@ -96,3 +96,18 @@ def free_response_to_question(question_id, answer_text):
 
     template = Template(xml_response)
     return template.substitute(locals())
+
+
+def select_response_to_question(question_id, answer_id):
+
+    xml_response = """
+<responses type="array">
+  <response>
+    <question-id>$question_id</question-id>
+    <answer-id>$answer_id</answer-id>
+  </response>
+</responses>
+"""
+
+    template = Template(xml_response)
+    return template.substitute(locals())


### PR DESCRIPTION
For the new conference registration functionality update, we need the ability to set subscribers' answers to **select** questions (i.e., questions that have set answers to choose from, as opposed to free response questions). This PR adds a method to do that.