### PR TITLE
Update dependencies

### DIFF
--- a/govdelivery/api.py
+++ b/govdelivery/api.py
@@ -1,17 +1,11 @@
-import six
-
 import base64
 import os
+import urllib.parse as urlparse
 from string import Template
 
 import requests
+
 from govdelivery import xml_payloads, xml_response_parsers
-
-if six.PY2:
-    import urlparse  # pragma: no cover
-else:
-    import urllib.parse as urlparse  # pragma: no cover
-
 
 GOVDELIVERY_BASE_URL = 'https://api.govdelivery.com'
 

--- a/govdelivery/tests/test_api.py
+++ b/govdelivery/tests/test_api.py
@@ -1,7 +1,10 @@
 import base64
 import unittest
+from unittest.mock import patch
 
 import responses
+from requests.models import Response
+
 from govdelivery.api import (
     GovDelivery,
     authenticated_session,
@@ -9,8 +12,6 @@ from govdelivery.api import (
 )
 from govdelivery.tests.utils import load_data
 from govdelivery.xml_response_parsers import topic_xml_as_dict
-from mock import patch
-from requests.models import Response
 
 
 class TestClientUtilities(unittest.TestCase):

--- a/govdelivery/xml_payloads.py
+++ b/govdelivery/xml_payloads.py
@@ -1,13 +1,9 @@
-import six
-
 import re
 import warnings
 from string import Template
 
 
 def format_phone(phone):
-    if six.PY2:
-        warnings.simplefilter('default')  # pragma: no cover
     warnings.warn(
         'The phone number formatter will be deprecated in a future release of '
         'govdelivery. Going forward, please ensure that your application '

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,11 @@ from setuptools import find_packages, setup
 
 long_description = open('README.md', 'r').read()
 
-install_requires = ['requests==2.22.0']
+install_requires = ['requests>=2.22.0,<3']
 
 testing_extras = [
-    'coverage==4.5.4',
-    'mock==2.0.0',
-    'responses==0.10.6',
+    'coverage',
+    'responses',
 ]
 
 setup(
@@ -20,7 +19,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='CC0',
-    version='1.3',
+    version='1.4.0',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,16 @@
 [tox]
-envlist=lint,py{27,36}
+envlist=lint,py{36,39}
 
 [testenv]
-install_command=pip install -e '.[testing]' {packages}
+deps = .[testing]
 commands=
     coverage erase
     coverage run --source='govdelivery' -m unittest discover {posargs}
     coverage report -m
 
 basepython=
-    py27: python2.7
     py36: python3.6
+    py39: python3.9
 
 [testenv:lint]
 basepython=python3.6
@@ -44,7 +44,6 @@ exclude =
 include_trailing_comma=1
 multi_line_output=3
 skip=.tox,migrations
-not_skip=__init__.py
 use_parentheses=1
 known_django=django
 known_future_library=future,six


### PR DESCRIPTION
This change removes Python 2 support and updates our dependency pin for requests. Requests 2.22.0 depends on a version of `urllib3` that contains a high severity CVE that's been flagged in [consumerfinance.gov](https://github.com/cfpb/consumerfinance.gov/security/dependabot/requirements/libraries.txt/urllib3/open). We need to loosen this pined dependency up in order to update it there.

This PR also anticipates a 1.4.0 release once it's merged.